### PR TITLE
Update phpunit to be PHP8 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor/
+.phpunit.result.cache
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: php
 sudo: false
 
 php:
-  - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
+  - '8.0'
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "chameleon-system/code-style-config": "dev-master@dev",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "^8.5.13"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Check/DiskSpaceCheckTest.php
+++ b/tests/Check/DiskSpaceCheckTest.php
@@ -156,7 +156,7 @@ class DiskSpaceCheckTest extends FileSystemTestCase
         $this->assertEquals($expectedOutcomeList, $actualOutcomeList);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Check/FileSystemTestCase.php
+++ b/tests/Check/FileSystemTestCase.php
@@ -58,7 +58,7 @@ class FileSystemTestCase extends TestCase
     public static $isWritable = array();
     public static $isExecutable = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Check/PhpModuleLoadedCheckTest.php
+++ b/tests/Check/PhpModuleLoadedCheckTest.php
@@ -78,7 +78,7 @@ class PhpModuleLoadedCheckTest extends TestCase
         $this->assertEquals($expectedOutcomeList, $actualOutcomeList);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         self::$extensionLoaded = array();

--- a/tests/Check/PhpRuntimeVersionCheckTest.php
+++ b/tests/Check/PhpRuntimeVersionCheckTest.php
@@ -87,7 +87,7 @@ class PhpRuntimeVersionCheckTest extends TestCase
         $this->phpRuntimeVersionCheck = new PhpRuntimeVersionCheck(CheckOutcome::ERROR, $version);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         self::$phpversion = '5.3.9';

--- a/tests/Handler/CheckHandlerTest.php
+++ b/tests/Handler/CheckHandlerTest.php
@@ -184,7 +184,7 @@ class CheckHandlerTest extends TestCase
         $this->assertEquals($expectedOutcomeList[1][0]->getLevel(), $outcomeList[1]->getLevel());
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->checkResolver = $this->prophesize(

--- a/tests/Resolver/CheckResolverTest.php
+++ b/tests/Resolver/CheckResolverTest.php
@@ -118,7 +118,7 @@ class CheckResolverTest extends TestCase
         $this->assertEquals($revealedCheck3, $checks[2]);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->checkResolver = new CheckResolver();

--- a/tests/Resolver/OutputResolverTest.php
+++ b/tests/Resolver/OutputResolverTest.php
@@ -44,7 +44,7 @@ class OutputResolverTest extends TestCase
         }
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->outputResolver = new OutputResolver();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#668   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In an effort to update core components to PHP8 this updates phpunit to 8.x. This makes the tests runnable in PHP8 but drops support for running tests in PHP7.1.
